### PR TITLE
feat: add required field * to inputs using isRequired prop

### DIFF
--- a/src/assets/scss/_input-text.scss
+++ b/src/assets/scss/_input-text.scss
@@ -19,6 +19,12 @@
     @apply w-8 h-8 border-gray3 border-r border-solid flex items-center justify-center absolute z-10 top-0 left-0;
   }
 
+  label {
+    span.required {
+      @apply text-red3;
+    }
+  }
+
   i {
     @apply h-6 w-6 block absolute z-10 cursor-pointer;
     top: 50%;

--- a/src/components/Input/Input.vue
+++ b/src/components/Input/Input.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="sol-input">
-    <label v-if="label" :for="id">{{ label }}</label>
+    <label v-if="label" :for="id">
+      {{ label }} <span v-if="isRequired" class="required">*</span>
+    </label>
     <div class="wrapper-input">
       <span v-if="!!$slots['icon']" class="icon">
         <!-- @slot Use this slot icon AddOns -->
@@ -131,6 +133,11 @@ export default {
 
     /** Allows control over field visibility for types text and password */
     controlVisibility: {
+      type: Boolean,
+      default: false,
+    },
+
+    isRequired: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
# Descrição

Adiciona ao componente Input a capacidade de inserir o * de obrigatoriedade do campo em frente a label usando a propriedade isRequired.

## Stories relacionadas (clubhouse)

- [ch-6739]

## Pontos para atenção

- A prop inicia como false, para abilitar basta passar isRequired como prop do componente.

## Possui novas configurações?

N/A

## Possui migrations?

N/A
