### PR TITLE
Ajuste iniciar em 0  - gráfico coluna

### DIFF
--- a/src/components/Charts/Bar/Bar.vue
+++ b/src/components/Charts/Bar/Bar.vue
@@ -109,6 +109,7 @@ export default {
               fontSize: '12',
               fontFamily: 'Lato, sans-serif',
               padding: 26,
+              beginAtZero: true,
             },
             gridLines: {
               drawBorder: false,


### PR DESCRIPTION
# Descrição

**Problema:**
Quando todos os dados vinham com 0, o gráfico gerava o índice negativo.

**Solução:**
Adicionado parâmetro para iniciar do 0.


## Stories relacionadas (clubhouse)

N/A

## Pontos para atenção

N/A

## Possui novas configurações?

N/A
