### PR TITLE
feat: add type as name if name is null

### DIFF
--- a/src/components/Input/Input.vue
+++ b/src/components/Input/Input.vue
@@ -21,7 +21,7 @@
         }"
         data-testid="input"
         :disabled="disabled"
-        :name="name"
+        :name="name || type"
         :placeholder="placeholder"
         :type="inputType"
         :value="value"


### PR DESCRIPTION
# Descrição

Coloca o name como type caso `name: null` no input

## O que isso muda?
Como `name` é uma prop **opcional**, podemos melhorar sua funcionalidade colocando como default o type dela. Isso sinaliza para o navegador o que sugerir no autofill automaticamente, melhorando bastante a experiência do usuário sem corromper nada no código já implementado.