### PR TITLE
No-wrap no badge quanto o text contem espaço

### DIFF
--- a/src/assets/scss/_badge.scss
+++ b/src/assets/scss/_badge.scss
@@ -1,6 +1,7 @@
 .sol-badge {
   @apply inline-flex items-center rounded font-rubik font-bold text-tiny uppercase h-5 px-2;
   line-height: 1.4;
+  white-space: nowrap;
 
   &:before {
     @apply w-2 h-2 rounded-full block mr-2;


### PR DESCRIPTION
Para previnir quebra de linha em badge com o text como `em aberto` inseri o `no-wrap` no css.

atual:
<img width="93" alt="Screen Shot 2021-10-27 at 5 38 35 PM" src="https://user-images.githubusercontent.com/438651/139143480-b141b3f6-47be-4a51-befe-03500ae01bb1.png">

