### PR TITLE
Alteração de layout (botões do footer e tamanho do modal)

### DIFF
--- a/src/assets/scss/_modal.scss
+++ b/src/assets/scss/_modal.scss
@@ -16,6 +16,7 @@
   .wrapper {
     @apply w-full mx-auto bg-white rounded  z-10;
     width: calc(100vw - 32px);
+    height: calc(100vh - 32px);
     max-width: 600px;
 
     &.size-lg {
@@ -24,10 +25,11 @@
 
     main {
       @apply text-small text-grayPrimary;
+      height: calc(100vh - 192px);
 
       .overflow {
         @apply pr-2 overflow-hidden overflow-y-auto;
-        max-height: calc(100vh - 286px);
+        max-height: calc(100vh - 241px);
 
         &.no-croll {
           overflow: initial;
@@ -66,7 +68,7 @@
   }
 
   footer {
-    @apply flex items-center bg-gray2 rounded;
+    @apply flex flex-row-reverse items-center bg-gray2 rounded;
     box-shadow: 0px -1px 0px #e0e0e0;
 
     .btn,
@@ -89,9 +91,11 @@
     }
 
     .wrapper {
+      height: fit-content;
       max-width: 900px;
 
       main {
+        height: fit-content;
         .overflow {
           max-height: calc(100vh - 334px);
         }


### PR DESCRIPTION
# Descrição

Alterações apenas no scss.

## Stories relacionadas (clubhouse)

- [sc-9425]

## Pontos para atenção

- Mudar os botões do footer do modal para o lado direito (mobile e desktop).
- Mudar o tamanho dos modais apenas na versão mobile, como no handoff.