### PR TITLE
locking node version in  package.json to avoid errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": false,
   "description": "Component library based on Vue and Tailwind",
   "author": "Solfacil - Fernando Jesus",
+  "engines": {
+    "node": "^14"
+  },
   "scripts": {
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@vue/cli-service": "~4.5.15",
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/test-utils": "^1.3.0",
+    "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.3",
     "babel-plugin-require-context-hook": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4361,7 +4361,7 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^7.0.0-bridge.0:
+babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==


### PR DESCRIPTION
# Description
I implemented "engines" to avoid installation dependencies with the newest or oldest node version.

vue-jest and another dependencies requires old babel version, so i needed add the "babel-core@7.0.0-bridge.0" explicitly to fix some errors