### PR TITLE
Feature/input valid outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solfacil/components-ui",
-  "version": "1.62.2",
+  "version": "1.62.3",
   "private": false,
   "description": "Component library based on Vue and Tailwind",
   "author": "Solfacil - Fernando Jesus",

--- a/src/assets/scss/_input-text.scss
+++ b/src/assets/scss/_input-text.scss
@@ -25,6 +25,10 @@
         margin: 0;
       }
     }
+
+    &.valid {
+      @apply border-green2;
+    }
   }
 
   .icon {

--- a/src/components/Input/Input.vue
+++ b/src/components/Input/Input.vue
@@ -19,6 +19,7 @@
           search: inputType === 'search',
           hasIconVisibility: controlVisibility,
           'no-arrows': noArrows,
+          valid: validOutline,
         }"
         data-testid="input"
         :disabled="disabled"
@@ -134,6 +135,12 @@ export default {
     placeholder: {
       type: String,
       default: null,
+    },
+
+    /** Provides a green "valid" border to the input */
+    validOutline: {
+      type: Boolean,
+      default: false,
     },
 
     /** Specify the type of the Input: <br/> "date" | "email" | "password"  | "search"  | "tel"  | "text"  | "time" | "url" | "number" */

--- a/src/components/Input/Input.vue
+++ b/src/components/Input/Input.vue
@@ -19,7 +19,7 @@
           search: inputType === 'search',
           hasIconVisibility: controlVisibility,
           'no-arrows': noArrows,
-          valid: validOutline,
+          valid: [false, isFieldValid][Number(validOutline)],
         }"
         data-testid="input"
         :disabled="disabled"
@@ -137,7 +137,7 @@ export default {
       default: null,
     },
 
-    /** Provides a green "valid" border to the input */
+    /** Specifies whether the field should display a green outline on valid state*/
     validOutline: {
       type: Boolean,
       default: false,
@@ -195,6 +195,10 @@ export default {
       if (type === 'tel') return '(##) #####-####';
 
       return '';
+    },
+
+    isFieldValid() {
+      return !this.$props.invalid && this.$props.value;
     },
   },
 


### PR DESCRIPTION
# Descrição

Adiciona a prop validOutline ao componente Input, ela habilitada no input a capacidade de adicionar uma borda verde em si quando seu status for válido e o valor não vazio. Feature necessária em decorrência da task [sc-5427].

## Stories relacionadas (clubhouse)

- [sc-5427]

## Pontos para atenção

- A prop não é obrigatória e funciona apenas como uma flag para que o componente adote o comportamento, todo controle relacionado ao campo ser válido ou não é feito dentro do próprio componente com as props invalid e value.
