### PR TITLE
Chore/modal custom close

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -14,7 +14,7 @@
           <IconClose
             v-if="!disableClose"
             class="icon-close"
-            @click="[customCloseAction, close][Number(selfClose)]"
+            @click="[closeSelf(), close()][selfClose]"
           />
         </header>
 

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -11,7 +11,11 @@
         <header>
           {{ title }}
 
-          <IconClose v-if="!disableClose" class="icon-close" @click="close" />
+          <IconClose
+            v-if="!disableClose"
+            class="icon-close"
+            @click="[customCloseAction, close][Number(selfClose)]"
+          />
         </header>
 
         <main>


### PR DESCRIPTION
# Descrição

Icone de fechar modal não chama método custom caso ele seja passado como parâmetro. Chore evita isso.

## Stories relacionadas (clubhouse)

- [sc-11883]
