### PR TITLE
fix: FilterComponent count filter custom type with value array and object 

### DIFF
--- a/src/components/FilterComponent/FilterComponent.vue
+++ b/src/components/FilterComponent/FilterComponent.vue
@@ -312,7 +312,6 @@ export default {
       return result(countObject, filter.type, countObject.default);
     },
     getCountCustom(filterSelected) {
-      console.info('filterSelected', filterSelected);
       if (
         ['array', 'object'].includes(
           filterSelected?.constructor?.name?.toLowerCase(),

--- a/src/components/FilterComponent/FilterComponent.vue
+++ b/src/components/FilterComponent/FilterComponent.vue
@@ -293,7 +293,6 @@ export default {
       this.count = 0;
       this.filters.forEach((filter) => {
         this.filterApplied[filter.name] = filterToApply[filter.name];
-        console.info(this.getCountByType(filter), filter.name);
         this.count = this.count + this.getCountByType(filter);
       });
 

--- a/src/components/FilterComponent/FilterComponent.vue
+++ b/src/components/FilterComponent/FilterComponent.vue
@@ -202,6 +202,7 @@ export default {
   watch: {
     filters: {
       handler: function () {
+        this.setupActiveFilter();
         this.setupFilters();
       },
       deep: true,
@@ -209,19 +210,21 @@ export default {
   },
 
   created() {
-    const filtersForActive = this.filters.filter(
-      (item) => !this.itemIsBinary(item),
-    );
-
-    if (filtersForActive && Boolean(filtersForActive.length)) {
-      this.activeFilter = { ...filtersForActive[0] };
-      this.activeIndex = 0;
-    }
-
+    this.setupActiveFilter();
     this.setupBinaryFilters();
     this.setupFilters();
   },
   methods: {
+    setupActiveFilter() {
+      const filtersForActive = this.filters.filter(
+        (item) => !this.itemIsBinary(item),
+      );
+
+      if (filtersForActive && Boolean(filtersForActive.length)) {
+        this.activeFilter = { ...filtersForActive[0] };
+        this.activeIndex = 0;
+      }
+    },
     getComponentItem(item) {
       const componentsObject = {
         list: 'FilterSelectList',

--- a/src/components/FilterComponent/FilterComponent.vue
+++ b/src/components/FilterComponent/FilterComponent.vue
@@ -293,6 +293,7 @@ export default {
       this.count = 0;
       this.filters.forEach((filter) => {
         this.filterApplied[filter.name] = filterToApply[filter.name];
+        console.info(this.getCountByType(filter), filter.name);
         this.count = this.count + this.getCountByType(filter);
       });
 
@@ -302,13 +303,26 @@ export default {
     },
 
     getCountByType(filter) {
+      const filterSelected = this.filtersSelected[filter.name];
       const countObject = {
-        list: this.filtersSelected[filter.name].length,
-        range: this.filtersSelected[filter.name].length > 1 ? 1 : 0,
-        default: this.filtersSelected[filter.name] ? 1 : 0,
+        list: filterSelected?.length,
+        range: filterSelected?.length > 1 ? 1 : 0,
+        default: this.getCountCustom(filterSelected),
       };
 
       return result(countObject, filter.type, countObject.default);
+    },
+    getCountCustom(filterSelected) {
+      console.info('filterSelected', filterSelected);
+      if (
+        ['array', 'object'].includes(
+          filterSelected?.constructor?.name?.toLowerCase(),
+        )
+      ) {
+        return Object.keys(filterSelected).length;
+      }
+
+      return filterSelected ? 1 : 0;
     },
     clearFilters() {
       this.setupFilters();

--- a/src/components/FilterComponent/FilterSelectList/FilterSelectList.vue
+++ b/src/components/FilterComponent/FilterSelectList/FilterSelectList.vue
@@ -77,12 +77,15 @@ export default {
           return true;
         }
 
-        return item.name.toLowerCase().includes(
-          this.searchString
-            .normalize('NFD')
-            .replace(/[^\w\d\s]/gu, '')
-            .toLowerCase(),
-        );
+        return item.name
+          .toString()
+          .toLowerCase()
+          .includes(
+            this.searchString
+              .normalize('NFD')
+              .replace(/[^\w\d\s]/gu, '')
+              .toLowerCase(),
+          );
       });
     },
   },


### PR DESCRIPTION
# Descrição
Este PR visa corrigir um pequeno que tem rolado na contagem de filtros aplicados do tipo custom que não levava em consideração filtros customizados que emitiam Array ou Object como valor no evento de `change`

## Stories relacionadas (clubhouse)

- [sc-11962](https://app.shortcut.com/solfacil/story/11962/implementar-componente-de-filtro-na-lib-de-ui)

## Pontos para atenção

- Listar pontos para atenção no review
- Listar pontos para atenção nos testes

## Possui novas configurações?

- Descrever as configurações alteradas ou novas
