### PR TITLE
refactor: :recycle: adding props to hide filter elements

### DIFF
--- a/src/assets/scss/_filtercomponent.scss
+++ b/src/assets/scss/_filtercomponent.scss
@@ -69,6 +69,10 @@
       dt {
         @apply flex items-center justify-between cursor-pointer font-normal font-rubik text-modest text-grayPrimary leading-tight p-4 border-t border-gray3 border-solid;
 
+        &:empty {
+          @apply hidden;
+        }
+
         &:first-of-type {
           @apply border-none;
         }
@@ -93,6 +97,10 @@
           @apply bg-gray1;
         }
       }
+    }
+
+    &.hide-search-mobile > dl {
+      @apply pb-0;
     }
 
     footer {
@@ -130,6 +138,10 @@
     &.open {
       @apply opacity-100 visible;
       top: calc(100% + 16px);
+    }
+
+    &.hide-nav-filters {
+      @apply w-auto;
     }
 
     nav {

--- a/src/components/FilterComponent/FilterComponent.stories.js
+++ b/src/components/FilterComponent/FilterComponent.stories.js
@@ -106,3 +106,49 @@ Default.args = {
   id: 'filter-component',
   filters,
 };
+
+export const PaymentFilter = Template.bind({});
+PaymentFilter.args = {
+  id: 'filter-component',
+  hideNavFilters: true,
+  hideSearch: true,
+  filters: [
+    {
+      type: 'list',
+      items: [
+        {
+          name: 'Teste01',
+          value: 1,
+        },
+        {
+          name: 'Teste02',
+          value: 2,
+        },
+        {
+          name: 'Teste03',
+          value: 3,
+        },
+        {
+          name: 'Teste04',
+          value: 4,
+        },
+        {
+          name: 'Teste05',
+          value: 5,
+        },
+        {
+          name: 'Teste06',
+          value: 6,
+        },
+        {
+          name: 'Teste07',
+          value: 7,
+        },
+        {
+          name: 'Teste08',
+          value: 8,
+        },
+      ],
+    },
+  ],
+};

--- a/src/components/FilterComponent/FilterComponent.vue
+++ b/src/components/FilterComponent/FilterComponent.vue
@@ -15,7 +15,16 @@
       <IconFilter :class="{ 'icon-count': count || showFilters }" />
     </span>
 
-    <div :class="[dropwnContentClass, { open: showFilters }]">
+    <div
+      :class="[
+        dropwnContentClass,
+        {
+          open: showFilters,
+          'hide-nav-filters': hideNavFilters,
+          'hide-search-mobile': hideSearch,
+        },
+      ]"
+    >
       <dl v-if="isMobile" class="filter-menu">
         <template v-for="(item, index) in filters">
           <dt
@@ -31,9 +40,7 @@
             @click="handleClickMenuItem({ item, index })"
           >
             <template v-if="itemIsBinary(item)">
-              <div class="label">
-                {{ item.name }}
-              </div>
+              <div class="label">{{ item.name }}</div>
               <ToggleSwitch
                 :id="`toggle-binary-${index}`"
                 v-model="binaryStates[item.name]"
@@ -42,9 +49,7 @@
                 @input="(value) => handleSwitch(value, item.name)"
               />
             </template>
-            <template v-else>
-              <span>{{ item.name }}</span>
-            </template>
+            <template v-else>{{ item.name }}</template>
           </dt>
 
           <transition
@@ -63,6 +68,7 @@
               <component
                 :is="getComponentItem(item)"
                 :id="`filter-body-active-${index}`"
+                :hide-search="hideSearch"
                 :value="filtersSelected[activeFilter.name]"
                 :filter="item"
                 @change="handleChangeFilterModel"
@@ -72,7 +78,7 @@
         </template>
       </dl>
 
-      <nav v-if="!isMobile">
+      <nav v-if="!isMobile && !hideNavFilters">
         <ul>
           <li
             v-for="(item, index) in filters"
@@ -84,9 +90,7 @@
             @click="handleClickMenuItem({ item, index })"
           >
             <template v-if="itemIsBinary(item)">
-              <div class="label">
-                {{ item.name }}
-              </div>
+              <div class="label">{{ item.name }}</div>
               <ToggleSwitch
                 :id="`toggle-binary-${index}`"
                 v-model="binaryStates[item.name]"
@@ -114,6 +118,7 @@
             v-if="isActiveItem(index)"
             :id="`filter-body-active-${index}`"
             :key="index"
+            :hide-search="hideSearch"
             :value="filtersSelected[activeFilter.name]"
             :filter="item"
             @change="handleChangeFilterModel"
@@ -127,13 +132,12 @@
           variant="secondary"
           size="small"
           @click="clearFilters"
+          >Limpar</Button
         >
-          Limpar
-        </Button>
 
-        <Button id="aplly" size="small" @click="applyFilters(true)">
-          Aplicar
-        </Button>
+        <Button id="aplly" size="small" @click="applyFilters(true)"
+          >Aplicar</Button
+        >
       </footer>
     </div>
   </div>
@@ -172,6 +176,17 @@ export default {
     filters: {
       type: Array,
       required: true,
+    },
+
+    /** Show left nav to navigate in different filters  */
+    hideNavFilters: {
+      type: Boolean,
+      default: () => false,
+    },
+
+    hideSearch: {
+      type: Boolean,
+      default: () => false,
     },
   },
 

--- a/src/components/FilterComponent/FilterSelectList/FilterSelectList.vue
+++ b/src/components/FilterComponent/FilterSelectList/FilterSelectList.vue
@@ -1,7 +1,7 @@
 <template>
   <div :id="id" class="sol-filterselectlist">
     <Input
-      v-if="hasScrolling"
+      v-if="hasScrolling && !hideSearch"
       id="filter-searchbar"
       v-model="searchString"
       class="filter-searchbar"
@@ -11,7 +11,7 @@
 
     <div
       ref="filterSelectlist"
-      :class="['list', { 'non-searchable': !hasScrolling }]"
+      :class="['list', { 'non-searchable': !hasScrolling || hideSearch }]"
     >
       <div
         v-for="item in items"
@@ -56,6 +56,11 @@ export default {
     placeholderSearch: {
       type: String,
       default: 'Busque aqui',
+    },
+
+    hideSearch: {
+      type: Boolean,
+      default: () => false,
     },
   },
 


### PR DESCRIPTION
# Descrição

Criação de _props_ para  customizar o filtro de lista padrão.

- `hideNavFilters`  Para esconder o sidebar esquerdo que aparece nos filtros
- `hideSearch` Para esconder a searchbar no componente de lista

Ambos ativos, terão o resultado igual ao print abaixo.

![image](https://user-images.githubusercontent.com/25128546/155607667-eebb49a2-33f0-420d-b0d7-37244f3f1d3b.png)
