### PR TITLE
fix: custom tab select and add stop propagation event in selectInput

### DIFF
--- a/src/components/FilterComponent/FilterComponent.vue
+++ b/src/components/FilterComponent/FilterComponent.vue
@@ -220,7 +220,11 @@ export default {
         (item) => !this.itemIsBinary(item),
       );
 
-      if (filtersForActive && Boolean(filtersForActive.length)) {
+      if (
+        filtersForActive &&
+        Boolean(filtersForActive.length) &&
+        !this.activeIndex
+      ) {
         this.activeFilter = { ...filtersForActive[0] };
         this.activeIndex = 0;
       }
@@ -266,8 +270,8 @@ export default {
     },
     handleClickMenuItem({ item, index }) {
       if (!this.itemIsBinary(item)) {
-        this.$set(this, 'activeFilter', this.filters[index]);
-        this.$set(this, 'activeIndex', index);
+        this.activeIndex = index;
+        this.activeFilter = { ...this.filters[index] };
       }
     },
     handleSwitch(value, name) {

--- a/src/components/FilterComponent/FilterComponent.vue
+++ b/src/components/FilterComponent/FilterComponent.vue
@@ -266,8 +266,8 @@ export default {
     },
     handleClickMenuItem({ item, index }) {
       if (!this.itemIsBinary(item)) {
-        this.activeFilter = this.filters[index];
-        this.activeIndex = index;
+        this.$set(this, 'activeFilter', this.filters[index]);
+        this.$set(this, 'activeIndex', index);
       }
     },
     handleSwitch(value, name) {

--- a/src/components/SelectInput/SelectInput.vue
+++ b/src/components/SelectInput/SelectInput.vue
@@ -64,7 +64,7 @@
         <li
           v-for="item in searchItems(searchString)"
           :key="item.value"
-          @click="selectItem(item)"
+          @click.stop="selectItem(item)"
         >
           {{ item.name }}
         </li>


### PR DESCRIPTION
# Descrição
Este PR visa corrigir um problema que ao usar o SelectInput o evento é propagado e chega até a diretiva `v-click-outside` que utilizamos para fechar os filtros e outros pontos tbm, isso ocorre pelo fato de trabalhar com um position absolute e com isso acaba não sendo entendido como se estivesse dentro do filtro pela diretiva. E por algum motivo em um caso bem especifico de filtro do tipo `custom` ao clicar uma vez na tab ele não a seleciona corretamente, isso ocorre por um bug no watch do value. 

## Stories relacionadas (clubhouse)

- [sc-4416](https://app.shortcut.com/solfacil/story/4416/adicionar-filtros-na-listagem-de-plantas)

## Pontos para atenção

- Listar pontos para atenção no review
- Listar pontos para atenção nos testes

## Possui novas configurações?

- Descrever as configurações alteradas ou novas
