### PR TITLE
fix: to set items when creating component

### DIFF
--- a/src/components/Multiselect/Multiselect.stories.js
+++ b/src/components/Multiselect/Multiselect.stories.js
@@ -24,7 +24,7 @@ const Template = (args, { argTypes }) => ({
     };
   },
   template:
-    '<div style="width:500px; min-height: 200px"><Multiselect v-bind="$props" :options="subjectTypes" v-model="inputModel" /></div>',
+    '<div style="width:500px; min-height: 200px"><Multiselect v-bind="$props" :options="subjectTypes" :value="inputModel" /></div>',
 });
 
 export const Default = Template.bind({});

--- a/src/components/Multiselect/Multiselect.unit.spec.js
+++ b/src/components/Multiselect/Multiselect.unit.spec.js
@@ -124,4 +124,73 @@ describe('Multiselect - Unit', () => {
       },
     ]);
   });
+
+  it('should call asigned selected if have value', async () => {
+    const assignSelectedFromOptions = jest.spyOn(
+      Multiselect.methods,
+      'assignSelectedFromOptions',
+    );
+    // declared new wrapper to have value on created
+    const _wrapper = shallowMount(Multiselect, {
+      propsData: {
+        id: 'multi-select-input-temporary',
+        value: ['1'],
+        options: [
+          {
+            value: '1',
+            name: 'Sou um cliente e quero tirar dúvidas',
+          },
+          {
+            value: '2',
+            name: 'Sou um integrador e quero tirar dúvidas',
+          },
+        ],
+      },
+    });
+    await _wrapper;
+
+    expect(assignSelectedFromOptions).toHaveBeenCalled();
+    expect(_wrapper.vm.selected).toStrictEqual([
+      {
+        value: '1',
+        name: 'Sou um cliente e quero tirar dúvidas',
+      },
+    ]);
+  });
+
+  it('should be set to selected if it has value', async () => {
+    // declared new wrapper to have value on created
+    const _wrapper = shallowMount(Multiselect, {
+      propsData: {
+        id: 'multi-select-input-temporary',
+        value: ['1', '2'],
+        options: [
+          {
+            value: '1',
+            name: 'Sou um cliente e quero tirar dúvidas',
+          },
+          {
+            value: '2',
+            name: 'Sou um integrador e quero tirar dúvidas',
+          },
+          {
+            value: '3',
+            name: 'Sou um funcionario e quero tirar dúvidas',
+          },
+        ],
+      },
+    });
+    await _wrapper;
+
+    expect(_wrapper.vm.selected).toStrictEqual([
+      {
+        value: '1',
+        name: 'Sou um cliente e quero tirar dúvidas',
+      },
+      {
+        value: '2',
+        name: 'Sou um integrador e quero tirar dúvidas',
+      },
+    ]);
+  });
 });

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -213,15 +213,22 @@ export default {
 
   watch: {
     options() {
-      this.selected = [];
+      const action = [
+        this.assignSelectedFromOptions,
+        () => (this.selected = []),
+      ][Number(!this.value)];
+
+      action();
+    },
+
+    value() {
+      this.assignSelectedFromOptions();
     },
   },
 
   created() {
     if (this.value) {
-      this.options.map((item) => {
-        if (item.value === this.value) this.selected = [...this.selected, item];
-      });
+      this.assignSelectedFromOptions();
     }
   },
 
@@ -278,6 +285,15 @@ export default {
           return name.includes(searchQuery);
         });
       } else return this.options;
+    },
+    assignSelectedFromOptions() {
+      let selectedValue = [];
+      this.value.forEach((item) => {
+        this.options.forEach((option) => {
+          if (option.value === item) selectedValue.push(option);
+        });
+      });
+      if (selectedValue) this.selected = selectedValue;
     },
   },
 };


### PR DESCRIPTION
# Descrição

Ao editar um item as informações já cadastradas não estava sendo setadas no multiselect, então foi adicionado para que no create do componente o mesmo set os valores já passados no value

## Stories relacionadas

- [sh-13518](https://app.shortcut.com/solfacil/story/13518/corrige-componente-de-multiselect-do-component-ui)