### PR TITLE
fix: standardizes component input and output object

### DIFF
--- a/src/components/Multiselect/Multiselect.stories.js
+++ b/src/components/Multiselect/Multiselect.stories.js
@@ -24,7 +24,7 @@ const Template = (args, { argTypes }) => ({
     };
   },
   template:
-    '<div style="width:500px; min-height: 200px"><Multiselect v-bind="$props" :options="subjectTypes" :value="inputModel" /></div>',
+    '<div style="width:500px; min-height: 200px"><Multiselect v-bind="$props" :options="subjectTypes" v-model="inputModel" /></div>',
 });
 
 export const Default = Template.bind({});

--- a/src/components/Multiselect/Multiselect.vue
+++ b/src/components/Multiselect/Multiselect.vue
@@ -243,6 +243,14 @@ export default {
 
     removeSelectedIndex(index) {
       this.selected.splice(index, 1);
+      this.$emit(
+        'input',
+        this.selected.map((select) => select.value),
+      );
+      this.$emit(
+        'change',
+        this.selected.map((select) => select.value),
+      );
     },
 
     selectItem(option) {
@@ -258,8 +266,14 @@ export default {
         this.selected = [...this.selected, option];
       }
 
-      this.$emit('input', this.selected);
-      this.$emit('change', this.selected);
+      this.$emit(
+        'input',
+        this.selected.map((select) => select.value),
+      );
+      this.$emit(
+        'change',
+        this.selected.map((select) => select.value),
+      );
     },
 
     isItemSelected(item) {


### PR DESCRIPTION
# Descrição

Padroniza a entrada e saída do componente para ser um array de ids.
Corrige quando exclui o selecionado pelo chip para atualizar o objeto de selecionados e emitir o input e change.

## Stories relacionadas (clubhouse)

- [sc-13518]