### PR TITLE
feat: include accents to 2words+ text field regex

### DIFF
--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -1,5 +1,5 @@
 export default {
-  hasTwoWordsOrMore: (value) => /([a-zA-Z]+\s?\b){2,}/.test(value),
+  hasTwoWordsOrMore: (value) => /^[A-zÀ-ú]+(\s[A-zÀ-ú]+){1,}$/.test(value),
   hasNumber: (value) => /^([^0-9]*)$/.test(value),
   hasAtLeastOneNumber: (value) => /\d+/.test(value),
   emailSolfacil: (condition) => (value) => {


### PR DESCRIPTION
# Descrição

Refatora o regex que verifica se uma string contêm 2 ou mais "palavras" para aceitar caracteres acentuados.

Nova regra:
`^[A-zÀ-ú]+(\s[A-zÀ-ú]+){1,}$`

- Começo da string
- Qualquer caractere entre a-z maiúsculo, minúsculo ou acentuado.
- espaço + Qualquer caractere entre a-z maiúsculo, minúsculo ou acentuado pelo menos uma vez
- Não finalizando em espaço, linebreak etc.

## Stories relacionadas (clubhouse)

- [sc-14780]
