### PR TITLE
feat: adjustment-in-production-chart-labels

### DIFF
--- a/src/components/Charts/Bar/Bar.vue
+++ b/src/components/Charts/Bar/Bar.vue
@@ -55,6 +55,11 @@ export default {
 
     options: {
       responsive: true,
+      hover: {
+        onHover: (event, chartElement) => {
+          event.target.style.cursor = chartElement[0] ? 'pointer' : 'default';
+        },
+      },
       legend: {
         display: false,
       },
@@ -184,7 +189,9 @@ export default {
           },
           title: function (tooltipItem) {
             return [
-              window.monthNames[moment(tooltipItem[0]['label']).format('M')],
+              window.monthNames[
+                moment(tooltipItem[0]['label']).format('M') - 1
+              ],
               moment(tooltipItem[0]['label']).format('DD/MM/YYYY'),
             ][Number(window.viewChart === 'month')];
           },
@@ -236,7 +243,7 @@ export default {
           }
 
           ctx.fillText(
-            this.monthNames[new Date(l).getMonth()],
+            this.monthNames[moment(l).format('M') - 1],
             x,
             yAxis.bottom + 29,
           );


### PR DESCRIPTION
# Descrição
Foram realizados os seguintes pontos:
- Ajuste do mês no gráfico de produção. 
- Alteração do ponteiro mouse nas barras do gráfico.

Fiz uma alteração trocando o `new Date()` pelo `moment()` pois quando havia uma data com dia 1 a função retornava como último dia do mês anterior, onde também ficava errado o mês mostrado na base do gráfico.

- Exemplo:

Função: `new Date("2021-01-01");`
Retorna: `Thu Dec 31 2020 21:00:00 GMT-0300 (Horário Padrão de Brasília)`

## Stories relacionadas (clubhouse)

- [sc-15848](https://app.shortcut.com/solfacil/story/15848/label-de-produção-do-mês-dentro-do-gráfico-do-ano)