### PR TITLE
[SEG-3437]: add min and max length on textarea

### DIFF
--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -21,6 +21,8 @@
         :name="name"
         :placeholder="placeholder"
         :value="value"
+        :minlength="minlength"
+        :maxlength="maxlength"
         @input="$emit('input', $event.target.value)"
         @keyup.enter="handleEvent($event.target.value)"
       />
@@ -107,6 +109,18 @@ export default {
     large: {
       type: Boolean,
       default: false,
+    },
+
+    /** Specify a min length */
+    minlength: {
+      type: String,
+      default: null,
+    },
+
+    /** Specify a max length */
+    maxlength: {
+      type: String,
+      default: null,
     },
   },
 


### PR DESCRIPTION
# Descrição

Recebe via props o minimo e maximo para um texto no componente textarea

## Stories relacionadas (clubhouse)

- [SEG-3439]

[SEG-3439]: https://solfacil.atlassian.net/browse/SEG-3439?atlOrigin=eyJpIjoiNTNkNTYxMjFjZDk3NDE5OWI1NTAzOGExODRkZmZmZTUiLCJwIjoiaiJ9
